### PR TITLE
removed "cmd_terminator" from db2cmd -t; parameter

### DIFF
--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -2251,7 +2251,7 @@ function! s:DB_DB2_execSql(str)
 
         let cmd = dbext_bin .  ' ' . dbext#DB_getWType("db2cmd_cmd_options")
         let cmd = cmd . ' ' .  s:DB_option('', dbext#DB_getWTypeDefault("extra"), ' ') .
-                    \ s:DB_option('-t', dbext#DB_getWType("cmd_terminator"), ' ') .
+                    \ '-t ' .
                     \ '-f ' . s:dbext_tempfile
     endif
 


### PR DESCRIPTION
db2cmd complains about "-t;" being DB21001E

http://publib.boulder.ibm.com/infocenter/db2luw/v9r5/index.jsp?topic=%2Fcom.ibm.db2.luw.messages.db2.doc%2Fdoc%2Fmdb201001e.html

not sure if this is the perfect solution but it fixed the crashing queries for me
