### PR TITLE
Fixing join in DBListColumns

### DIFF
--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -1203,7 +1203,7 @@ function! s:DB_varToString(name)
     endif
 endfunction
 
-"FIXME: Csinálni kell erre egy kommandot.
+"FIXME: Csinï¿½lni kell erre egy kommandot.
 function! s:DB_getParameters(scope)
     "scope must be 'b', 'g', 'd' (buffer, global, default)
     if (a:scope == "b")
@@ -2209,9 +2209,9 @@ function! s:DB_DB2_execSql(str)
     " In batch files I used the following
     "     -c close when done
     "     -w wait until command finishes
-    "     -i don’t spawn a new cmd window
-    "     -t don’t change the window title
-    "     db2cmd -c -w -i –t “db2 -s -t ; -v -f dave.sql”
+    "     -i donï¿½t spawn a new cmd window
+    "     -t donï¿½t change the window title
+    "     db2cmd -c -w -i ï¿½t ï¿½db2 -s -t ; -v -f dave.sqlï¿½
     " To see command line options
     "     cd IBM\SQLLIB\BIN
     "     db2cmd -w -i
@@ -3224,7 +3224,7 @@ function! s:DB_PGSQL_getListColumn(table_name)
     let table_name = s:DB_getObjectName(a:table_name)
     let query =   "SELECT a.attname                  " .
                 \ "  FROM pg_class c, pg_attribute a " .
-                \ " WHERE c.relfilenode = a.attrelid " .
+                \ " WHERE c.oid = a.attrelid " .
                 \ "   AND a.attnum > 0               " .
                 \ "   AND c.relname = '" . table_name . "'"
  


### PR DESCRIPTION
Without using the `oid` field to join we can get an error: "dbext:Table not found" when the relfilenode is not equal the relation's oid.
