### PR TITLE
my naive attempt to prevent special chars in passwords causing troubles

### DIFF
--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -817,7 +817,9 @@ function! s:DB_get(name, ...)
             let retval = s:DB_promptForParameters(a:name)
         endif
     endif
-
+    if a:name == 'passwd'
+        let retval = "'" . retval . "'"
+    endif
     return retval
 endfunction
 


### PR DESCRIPTION
I have not edited vim plugins before, but I was having trouble using dbext when attempting to use my generated password to connect to a remote database. This has solved the problem for me. The only case I can think of where this wouldn't solve the issue I was having would be if there was a single quotation mark in the password.