### PR TITLE
Postgres search_path relies on schema rather than tableowner.

### DIFF
--- a/autoload/dbext.vim
+++ b/autoload/dbext.vim
@@ -3556,10 +3556,10 @@ endfunction
 function! s:DB_PGSQL_getListTable(table_prefix)
     let owner      = s:DB_getObjectOwner(a:table_prefix)
     let table_name = s:DB_getObjectName(a:table_prefix)
-    let query = "select tablename, tableowner " .
+    let query = "select tablename, schemaname " .
                 \ " from pg_tables " .
-                \ "where tableowner != 'pg_catalog' " .
-                \ "  and tableowner like '" . owner . "%' " .
+                \ "where schemaname != 'pg_catalog' " .
+                \ "  and schemaname like '" . owner . "%' " .
                 \ "  and tablename  like '" . table_name . "%' " .
                 \ "order by tablename"
     return s:DB_PGSQL_execSql(query)
@@ -3622,10 +3622,10 @@ endfunction
 
 function! s:DB_PGSQL_getDictionaryTable()
     let result = s:DB_PGSQL_execSql(
-                \ "select ".(s:DB_get('dict_show_owner')==1?"tableowner||'.'||":'')."tablename " .
+                \ "select ".(s:DB_get('dict_show_owner')==1?"schemaname||'.'||":'')."tablename " .
                 \ " from pg_tables " .
-                \ "where tableowner != 'pg_catalog' " .
-                \ "order by ".(s:DB_get('dict_show_owner')==1?"tableowner, ":'')."tablename"
+                \ "where schemaname != 'pg_catalog' " .
+                \ "order by ".(s:DB_get('dict_show_owner')==1?"schemaname, ":'')."tablename"
                 \ )
     return s:DB_PGSQL_stripHeaderFooter(result)
 endfunction

--- a/doc/dbext.txt
+++ b/doc/dbext.txt
@@ -3745,13 +3745,13 @@ To specify the type of database you connect to most often, you can place the
  dbext's current variable_def_regex for this buffer.  This |autocmd| can be
  added to your |.vimrc|: >
         autocmd BufRead */MyProjectDir/* DBSetOption variable_def_regex=\<\(p_\|lv_\)\w\+\>
-        autocmd BufRead */MyProjectDir/* if exists('g:loaded_dbext') | exec 'DBSetOption variable_def_regex=\<\(p_\|lv_\)\w\+\>' | endif
+        autocmd BufRead /MyProjectDir/ if exists('g:loaded_dbext') | exec 'DBSetOption variable_def_regex=\<\(p_\|lv_\)\w\+\>' | endif
 <
  Or if you simply wanted to extended the existing defaults, you can
  retrieve the existing setting using dbext's DB_listOption function and
  concatenate the new regex separated by a comma: >
         autocmd BufRead */MyProjectDir2/* DBSetOption variable_def_regex=,\<\(p_\|lv_\)\w\+\>
-        autocmd BufRead */MyProjectDir2/* if exists('g:loaded_dbext') | exec 'DBSetOption variable_def_regex=,\<\(p_\|lv_\)\w\+\>' | endif
+        autocmd BufRead /MyProjectDir2/ if exists('g:loaded_dbext') | exec 'DBSetOption variable_def_regex=,\<\(p_\|lv_\)\w\+\>' | endif
 <
 
  Prompt screens and options.


### PR DESCRIPTION
For PostgreSQL:
Change the table description and table complete list from `tableowner` to `schemaname` because the object resolution in Postgres relies on schema in `search_path`. See http://www.postgresql.org/docs/9.4/static/ddl-schemas.html
