### PR TITLE
add .gitignore with /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
In my case, I get vim modules as git submodules in my dotfiles, using
Tim Pope's pathogen. The help tags make the repo dirty and I think they
should be ignored.

Thanks!
