### PR TITLE
Update .gitignore to add tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/doc/tags
+tags


### PR DESCRIPTION
`/doc/tags` gets auto-created upon plugin install (i am using Vundle plugin manager, believe this is vim behaviour). When using git submodules, the existence of `/doc/tags` causes git errors indicating untracked content. Noticed that many other vim plugins account for this, and add `tags` or `doc/tags` to their .gitignore files -
for example: [vim-fugitive](https://github.com/tpope/vim-fugitive/blob/master/.gitignore), [nerdcommenter](https://github.com/scrooloose/nerdcommenter/blob/master/.gitignore) or [tabular](https://github.com/godlygeek/tabular/blob/master/.gitignore).  Have about 60 plugins, and only 4 currently missing `tags` in their .gitignore - please consider accepting this PR.